### PR TITLE
コメント装飾の変更

### DIFF
--- a/projects/CommentGenerator/GenerateCommentCommand.cs
+++ b/projects/CommentGenerator/GenerateCommentCommand.cs
@@ -361,8 +361,9 @@ namespace CommentGenerator
 				comments.Add(commentDecoration_);
 			}
 
-			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// <summary>");
 			comments.Add("/// ");
+			comments.Add("/// </summary>");
 
 			//ジェネリックな関数の場合typeparamコメントを追加する必要があるが
 			//関数が使用しているgeneric typeを取得するプロパティが無い
@@ -478,8 +479,9 @@ namespace CommentGenerator
 				comments.Add(commentDecoration_);
 			}
 
-			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// <summary>");
 			comments.Add("/// ");
+			comments.Add("/// </summary>");
 
 			for (int j = 1; j <= propertyInfo.Parameters.Count; ++j) {
 				CodeParameter paramInfo = (CodeParameter)propertyInfo.Parameters.Item(j);
@@ -517,8 +519,9 @@ namespace CommentGenerator
 				comments.Add(commentDecoration_);
 			}
 
-			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// <summary>");
 			comments.Add("/// ");
+			comments.Add("/// </summary>");
 
 			//FxCopの規約により引き数名はsenderとeになっているはずなので決め打ちする
 			//と行きたいところだけど、
@@ -563,12 +566,9 @@ namespace CommentGenerator
 				comments.Add(classCommentDecoration2_);
 			}
 
-			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// <summary>");
 			comments.Add("/// ");
-			comments.Add("/// <remarks>");
-			comments.Add("/// ");
-			comments.Add("/// </remarks>");
-
+			comments.Add("/// </summary>");
 			//ジェネリックなクラスの場合もジェネリック関数の時と同じ
 			var elementNames = fullName.Split('.');
 			if (elementNames.Length > 0) {

--- a/projects/CommentGenerator/GenerateCommentCommand.cs
+++ b/projects/CommentGenerator/GenerateCommentCommand.cs
@@ -76,7 +76,23 @@ namespace CommentGenerator
 		}
 
 		/// <summary>改行文字を表す定数</summary>
-		static private readonly string newLine_ = System.Environment.NewLine;
+		private static readonly string newLine_ = System.Environment.NewLine;
+
+		/// <summary>ファイルヘッダーの装飾</summary>
+		private static readonly string headerDecoration_
+			= "//================================================================================================//";
+
+		/// <summary>クラスコメントの装飾１</summary>
+		private static readonly string classCommentDecoration1_
+			= "//============================================================================================//";
+		/// <summary>クラスコメントの装飾２</summary>
+		private static readonly string classCommentDecoration2_
+			= "//--------------------------------------------------------------------------------------------//";
+
+		/// <summary>コメントの装飾</summary>
+		private static readonly string commentDecoration_
+			= "//------------------------------------------------------------------------------------//";
+
 		/// <summary>ユーザー設定</summary>
 		private SettingPage setting_;
 
@@ -309,17 +325,21 @@ namespace CommentGenerator
 			//１行１行出力していくとコードレンズが重いので
 			//他の所と同じようにまとめて出力するように切り替える
 
-			List<string> comments = new List<string> {
-				"//************************************************************************************************//",
-				"//! @author " + setting_.Author,
-				"//! @date   " + DateTime.Now.ToString(setting_.DateFormat),
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesFileHeader) {
+				comments.Add(headerDecoration_);
+			}
+
+			comments.Add("//! @author " + setting_.Author);
+			comments.Add("//! @date   " + DateTime.Now.ToString(setting_.DateFormat));
 
 			if (setting_.WritesCopyright) {
 				comments.Add("//! @note   " + setting_.Copyright);
 			}
 
-			comments.Add("//************************************************************************************************//");
+			if (setting_.DecoratesFileHeader) {
+				comments.Add(headerDecoration_);
+			}
 
 			//ファイルの先頭に移動
 			ts.StartOfLine();
@@ -333,11 +353,13 @@ namespace CommentGenerator
 
 			CodeFunction functionInfo = (CodeFunction)element;
 
-			List<string> comments = new List<string> {
-				"//------------------------------------------------------------------------------------//",
-				"/// <summary>" + "</summary>",
-				"/// "
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
+
+			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// ");
 
 			//ジェネリックな関数の場合typeparamコメントを追加する必要があるが
 			//関数が使用しているgeneric typeを取得するプロパティが無い
@@ -373,7 +395,9 @@ namespace CommentGenerator
 			comments.Add("/// <returns>" + "</returns>");
 			comments.Add("/// <exception cref=\"Exception\">" + "</exception>");
 			comments.Add("//! @author " + setting_.Author);
-			comments.Add("//------------------------------------------------------------------------------------//");
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
 
 			//要素の先頭へ移動
 			ts.MoveToPoint(functionInfo.StartPoint);
@@ -443,11 +467,13 @@ namespace CommentGenerator
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			List<string> comments = new List<string> {
-				"//------------------------------------------------------------------------------------//",
-				"/// <summary>" + "</summary>",
-				"/// "
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
+
+			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// ");
 
 			for (int j = 1; j <= propertyInfo.Parameters.Count; ++j) {
 				CodeParameter paramInfo = (CodeParameter)propertyInfo.Parameters.Item(j);
@@ -456,7 +482,9 @@ namespace CommentGenerator
 
 			comments.Add("/// <returns>" + "</returns>");
 			comments.Add("//! @author " + setting_.Author);
-			comments.Add("//------------------------------------------------------------------------------------//");
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
 
 			//要素の先頭へ移動
 			ts.MoveToPoint(propertyInfo.StartPoint);
@@ -475,11 +503,13 @@ namespace CommentGenerator
 
 			CodeDelegate delegateInfo = (CodeDelegate)element;
 
-			List<string> comments = new List<string> {
-				"//------------------------------------------------------------------------------------//",
-				"/// <summary>" + "</summary>",
-				"/// "
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
+
+			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// ");
 
 			//FxCopの規約により引き数名はsenderとeになっているはずなので決め打ちする
 			//と行きたいところだけど、
@@ -496,7 +526,9 @@ namespace CommentGenerator
 			}
 
 			comments.Add("//! @author " + setting_.Author);
-			comments.Add("//------------------------------------------------------------------------------------//");
+			if (setting_.DecoratesComment) {
+				comments.Add(commentDecoration_);
+			}
 
 			//定義の先頭へ移動
 			ts.MoveToPoint(element.StartPoint);
@@ -513,15 +545,17 @@ namespace CommentGenerator
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			List<string> comments = new List<string> {
-				"//********************************************************************************************//",
-				"//--------------------------------------------------------------------------------------------//",
-				"/// <summary>" + "</summary>",
-				"/// ",
-				"/// <remarks>",
-				"/// ",
-				"/// </remarks>"
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesComment) {
+				comments.Add(classCommentDecoration1_);
+				comments.Add(classCommentDecoration2_);
+			}
+
+			comments.Add("/// <summary>" + "</summary>");
+			comments.Add("/// ");
+			comments.Add("/// <remarks>");
+			comments.Add("/// ");
+			comments.Add("/// </remarks>");
 
 			//ジェネリックなクラスの場合もジェネリック関数の時と同じ
 			var elementNames = fullName.Split('.');
@@ -542,7 +576,9 @@ namespace CommentGenerator
 			}
 
 			comments.Add("//! @author " + setting_.Author);
-			comments.Add("//--------------------------------------------------------------------------------------------//");
+			if (setting_.DecoratesComment) {
+				comments.Add(classCommentDecoration2_);
+			}
 
 			//クラス宣言の先頭へ移動
 			ts.MoveToPoint(element.StartPoint);
@@ -573,18 +609,25 @@ namespace CommentGenerator
 			GenerateClassCommentCore(ts, element, fullName);
 		}
 
-		private void GenerateEnumCommentCore(TextSelection ts, CodeElement element)
+		private void GenerateStructCommentCore(TextSelection ts, CodeElement element)
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			List<string> comments = new List<string> {
-				"/// <summary>",
-				"/// ",
-				"/// </summary>",
-				"//! @author " + setting_.Author
-			};
+			List<string> comments = new List<string>();
+			if (setting_.DecoratesComment) {
+				comments.Add(classCommentDecoration1_);
+				comments.Add(classCommentDecoration2_);
+			}
 
-			//enum宣言の先頭へ移動
+			comments.Add("/// <summary>");
+			comments.Add("/// ");
+			comments.Add("/// </summary>");
+			comments.Add("//! @author " + setting_.Author);
+			if (setting_.DecoratesComment) {
+				comments.Add(classCommentDecoration2_);
+			}
+
+			//構造体宣言の先頭へ移動
 			ts.MoveToPoint(element.StartPoint);
 			//インデントの取得
 			string indent = GetIndentText(ts);
@@ -599,14 +642,14 @@ namespace CommentGenerator
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			GenerateEnumCommentCore(ts, element);
+			GenerateStructCommentCore(ts, element);
 		}
 
 		private void GenerateStructComment(TextSelection ts, CodeElement element)
 		{
 			ThreadHelper.ThrowIfNotOnUIThread();
 
-			GenerateEnumCommentCore(ts, element);
+			GenerateStructCommentCore(ts, element);
 		}
 
 		//名前空間に再対応するときのために取っておくが、

--- a/projects/CommentGenerator/GenerateCommentCommand.cs
+++ b/projects/CommentGenerator/GenerateCommentCommand.cs
@@ -1,8 +1,8 @@
-﻿//************************************************************************************************//
+﻿//================================================================================================//
 //! @author SAITO Takamasa
 //! @date   2019-05-03
 //! @note   Copyright (c) ELIONIX.Inc. All rights reserved.
-//************************************************************************************************//
+//================================================================================================//
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
@@ -330,7 +330,10 @@ namespace CommentGenerator
 				comments.Add(headerDecoration_);
 			}
 
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor != AuthorSignKind.No) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			comments.Add("//! @date   " + DateTime.Now.ToString(setting_.DateFormat));
 
 			if (setting_.WritesCopyright) {
@@ -394,7 +397,10 @@ namespace CommentGenerator
 			}
 			comments.Add("/// <returns>" + "</returns>");
 			comments.Add("/// <exception cref=\"Exception\">" + "</exception>");
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor == AuthorSignKind.Yes) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			if (setting_.DecoratesComment) {
 				comments.Add(commentDecoration_);
 			}
@@ -481,7 +487,10 @@ namespace CommentGenerator
 			}
 
 			comments.Add("/// <returns>" + "</returns>");
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor == AuthorSignKind.Yes) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			if (setting_.DecoratesComment) {
 				comments.Add(commentDecoration_);
 			}
@@ -525,7 +534,10 @@ namespace CommentGenerator
 				}
 			}
 
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor == AuthorSignKind.Yes) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			if (setting_.DecoratesComment) {
 				comments.Add(commentDecoration_);
 			}
@@ -575,7 +587,10 @@ namespace CommentGenerator
 				}
 			}
 
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor == AuthorSignKind.Yes) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			if (setting_.DecoratesComment) {
 				comments.Add(classCommentDecoration2_);
 			}
@@ -622,7 +637,10 @@ namespace CommentGenerator
 			comments.Add("/// <summary>");
 			comments.Add("/// ");
 			comments.Add("/// </summary>");
-			comments.Add("//! @author " + setting_.Author);
+			if (setting_.SignsAuthor == AuthorSignKind.Yes) {
+				comments.Add("//! @author " + setting_.Author);
+			}
+
 			if (setting_.DecoratesComment) {
 				comments.Add(classCommentDecoration2_);
 			}

--- a/projects/CommentGenerator/GenerateCommentCommand.cs
+++ b/projects/CommentGenerator/GenerateCommentCommand.cs
@@ -77,12 +77,8 @@ namespace CommentGenerator
 
 		/// <summary>改行文字を表す定数</summary>
 		static private readonly string newLine_ = System.Environment.NewLine;
-		/// <summary>拡張機能を使用する人の名前</summary>
-		private string author_ = "";
-		/// <summary>コピーライト表記</summary>
-		private string copyright_ = "";
-		/// <summary>日付文字列の書式</summary>
-		private string dateFormat_ = "";
+		/// <summary>ユーザー設定</summary>
+		private SettingPage setting_;
 
 		/// <summary>
 		/// Initializes the singleton instance of the command.
@@ -110,9 +106,7 @@ namespace CommentGenerator
 			ThreadHelper.ThrowIfNotOnUIThread();
 
 			var package = this.package as CommentExtensionPackage;
-			author_ = package.Setting.Author;
-			copyright_ = package.Setting.Copyright;
-			dateFormat_ = package.Setting.DateFormat;
+			setting_ = package.Setting;
 
 			GenerateComment();
 		}
@@ -317,11 +311,15 @@ namespace CommentGenerator
 
 			List<string> comments = new List<string> {
 				"//************************************************************************************************//",
-				"//! @author " + author_,
-				"//! @date   " + DateTime.Now.ToString(dateFormat_),
-				"//! @note   " + copyright_,
-				"//************************************************************************************************//"
+				"//! @author " + setting_.Author,
+				"//! @date   " + DateTime.Now.ToString(setting_.DateFormat),
 			};
+
+			if (setting_.WritesCopyright) {
+				comments.Add("//! @note   " + setting_.Copyright);
+			}
+
+			comments.Add("//************************************************************************************************//");
 
 			//ファイルの先頭に移動
 			ts.StartOfLine();
@@ -374,7 +372,7 @@ namespace CommentGenerator
 			}
 			comments.Add("/// <returns>" + "</returns>");
 			comments.Add("/// <exception cref=\"Exception\">" + "</exception>");
-			comments.Add("//! @author " + author_);
+			comments.Add("//! @author " + setting_.Author);
 			comments.Add("//------------------------------------------------------------------------------------//");
 
 			//要素の先頭へ移動
@@ -457,7 +455,7 @@ namespace CommentGenerator
 			}
 
 			comments.Add("/// <returns>" + "</returns>");
-			comments.Add("//! @author " + author_);
+			comments.Add("//! @author " + setting_.Author);
 			comments.Add("//------------------------------------------------------------------------------------//");
 
 			//要素の先頭へ移動
@@ -497,7 +495,7 @@ namespace CommentGenerator
 				}
 			}
 
-			comments.Add("//! @author " + author_);
+			comments.Add("//! @author " + setting_.Author);
 			comments.Add("//------------------------------------------------------------------------------------//");
 
 			//定義の先頭へ移動
@@ -543,7 +541,7 @@ namespace CommentGenerator
 				}
 			}
 
-			comments.Add("//! @author " + author_);
+			comments.Add("//! @author " + setting_.Author);
 			comments.Add("//--------------------------------------------------------------------------------------------//");
 
 			//クラス宣言の先頭へ移動
@@ -583,7 +581,7 @@ namespace CommentGenerator
 				"/// <summary>",
 				"/// ",
 				"/// </summary>",
-				"//! @author " + author_
+				"//! @author " + setting_.Author
 			};
 
 			//enum宣言の先頭へ移動

--- a/projects/CommentGenerator/SettingPage.cs
+++ b/projects/CommentGenerator/SettingPage.cs
@@ -21,16 +21,32 @@ namespace CommentGenerator
 	//--------------------------------------------------------------------------------------------//
 	public class SettingPage : DialogPage
 	{
+		/// <summary>ファイルヘッダーや関数コメントに記述される著者名</summary>
+		[DefaultValue("ELIONIX")]
 		[LocalizedCategory("Signings")]
 		[LocalizedDisplayName("Author")]
 		[LocalizedDescription("Author")]
 		public string Author { get; set; } = "ELIONIX";
 
+		/// <summary>true: ファイルヘッダーにコピーライト文字列を出力する</summary>
+		[DefaultValue(true)]
+		[LocalizedCategory("Signings")]
+		[LocalizedDisplayName("WritesCopyright")]
+		[LocalizedDescription("WritesCopyright")]
+		public bool WritesCopyright { get; set; } = true;
+
+		/// <summary>ファイルヘッダーに記述されるコピーライト文言</summary>
+		[DefaultValue("Copyright (c) ELIONIX.Inc. All rights reserved.")]
 		[LocalizedCategory("Signings")]
 		[LocalizedDisplayName("Copyright")]
 		[LocalizedDescription("Copyright")]
 		public string Copyright { get; set; } = "Copyright (c) ELIONIX.Inc. All rights reserved.";
 
+		/// <summary>
+		/// 日付フォーマット。
+		/// DateTime.ToStringに渡す引数となる。
+		/// </summary>
+		[DefaultValue("yyyy-MM-dd")]
 		[LocalizedCategory("Formats")]
 		[LocalizedDisplayName("DateFormat")]
 		[LocalizedDescription("DateFormat")]

--- a/projects/CommentGenerator/SettingPage.cs
+++ b/projects/CommentGenerator/SettingPage.cs
@@ -21,17 +21,17 @@ namespace CommentGenerator
 	//--------------------------------------------------------------------------------------------//
 	public class SettingPage : DialogPage
 	{
-		[LocalizedCategory("Constants")]
-		[LocalizedDisplayName("Copyright")]
-		[LocalizedDescription("Copyright")]
-		public string Copyright { get; set; } = "Copyright (c) ELIONIX.Inc. All rights reserved.";
-
-		[LocalizedCategory("Constants")]
+		[LocalizedCategory("Signings")]
 		[LocalizedDisplayName("Author")]
 		[LocalizedDescription("Author")]
 		public string Author { get; set; } = "ELIONIX";
 
-		[LocalizedCategory("Constants")]
+		[LocalizedCategory("Signings")]
+		[LocalizedDisplayName("Copyright")]
+		[LocalizedDescription("Copyright")]
+		public string Copyright { get; set; } = "Copyright (c) ELIONIX.Inc. All rights reserved.";
+
+		[LocalizedCategory("Formats")]
 		[LocalizedDisplayName("DateFormat")]
 		[LocalizedDescription("DateFormat")]
 		public string DateFormat { get; set; } = "yyyy-MM-dd";

--- a/projects/CommentGenerator/SettingPage.cs
+++ b/projects/CommentGenerator/SettingPage.cs
@@ -51,5 +51,19 @@ namespace CommentGenerator
 		[LocalizedDisplayName("DateFormat")]
 		[LocalizedDescription("DateFormat")]
 		public string DateFormat { get; set; } = "yyyy-MM-dd";
+
+		/// <summary>true: ファイルヘッダーのコメントに装飾を付ける</summary>
+		[DefaultValue(true)]
+		[LocalizedCategory("Formats")]
+		[LocalizedDisplayName("DecoratesFileHeader")]
+		[LocalizedDescription("DecoratesFileHeader")]
+		public bool DecoratesFileHeader { get; set; } = true;
+
+		/// <summary>true: クラスや関数等のコメントに装飾を付ける</summary>
+		[DefaultValue(true)]
+		[LocalizedCategory("Formats")]
+		[LocalizedDisplayName("DecoratesComment")]
+		[LocalizedDescription("DecoratesComment")]
+		public bool DecoratesComment { get; set; } = true;
 	}
 }

--- a/projects/CommentGenerator/SettingPage.cs
+++ b/projects/CommentGenerator/SettingPage.cs
@@ -1,8 +1,8 @@
-﻿//************************************************************************************************//
+﻿//================================================================================================//
 //! @author SAITO Takamasa
 //! @date   2019-05-04
 //! @note   Copyright (c) ELIONIX.Inc. All rights reserved.
-//************************************************************************************************//
+//================================================================================================//
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -13,10 +13,11 @@ using Microsoft.VisualStudio.Shell;
 
 namespace CommentGenerator
 {
-	//********************************************************************************************//
+	//============================================================================================//
 	//--------------------------------------------------------------------------------------------//
-	/// <summary>ユーザー設定ページのクラス</summary>
-	/// 
+	/// <summary>
+	/// ユーザー設定ページのクラス
+	/// </summary>
 	//! @author SAITO Takamasa
 	//--------------------------------------------------------------------------------------------//
 	public class SettingPage : DialogPage
@@ -28,19 +29,27 @@ namespace CommentGenerator
 		[LocalizedDescription("Author")]
 		public string Author { get; set; } = "ELIONIX";
 
-		/// <summary>true: ファイルヘッダーにコピーライト文字列を出力する</summary>
-		[DefaultValue(true)]
-		[LocalizedCategory("Signings")]
-		[LocalizedDisplayName("WritesCopyright")]
-		[LocalizedDescription("WritesCopyright")]
-		public bool WritesCopyright { get; set; } = true;
-
 		/// <summary>ファイルヘッダーに記述されるコピーライト文言</summary>
 		[DefaultValue("Copyright (c) ELIONIX.Inc. All rights reserved.")]
 		[LocalizedCategory("Signings")]
 		[LocalizedDisplayName("Copyright")]
 		[LocalizedDescription("Copyright")]
 		public string Copyright { get; set; } = "Copyright (c) ELIONIX.Inc. All rights reserved.";
+
+
+		/// <summary>true: ファイルヘッダーにコピーライト文字列を出力する</summary>
+		[DefaultValue(true)]
+		[LocalizedCategory("Formats")]
+		[LocalizedDisplayName("WritesCopyright")]
+		[LocalizedDescription("WritesCopyright")]
+		public bool WritesCopyright { get; set; } = true;
+
+		/// <summary>著者の記述を行うかどうか</summary>
+		[DefaultValue((object)AuthorSignKind.Yes)]
+		[LocalizedCategory("Formats")]
+		[LocalizedDisplayName("SignsAuthor")]
+		[LocalizedDescription("SignsAuthor")]
+		public AuthorSignKind SignsAuthor { get; set; } = AuthorSignKind.Yes;
 
 		/// <summary>
 		/// 日付フォーマット。
@@ -65,5 +74,21 @@ namespace CommentGenerator
 		[LocalizedDisplayName("DecoratesComment")]
 		[LocalizedDescription("DecoratesComment")]
 		public bool DecoratesComment { get; set; } = true;
+	}
+
+	/// <summary>
+	/// 著者のコメントを記述するかどうか
+	/// </summary>
+	//! @author SAITO Takamasa
+	public enum AuthorSignKind
+	{
+		/// <summary>記述する</summary>
+		Yes,
+
+		/// <summary>ファイルヘッダーにのみ記述</summary>
+		OnlyHeader,
+
+		/// <summary>記述しない</summary>
+		No,
 	}
 }

--- a/projects/CommentGenerator/VSPackage.Designer.cs
+++ b/projects/CommentGenerator/VSPackage.Designer.cs
@@ -151,6 +151,15 @@ namespace CommentGenerator {
         }
         
         /// <summary>
+        ///   Decide where to write the author&apos;s sign. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DescriptionSignsAuthor {
+            get {
+                return ResourceManager.GetString("DescriptionSignsAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   If set to true, write copyright to the file header. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DescriptionWritesCopyright {
@@ -201,6 +210,15 @@ namespace CommentGenerator {
         internal static string DisplayNameDecoratesFileHeader {
             get {
                 return ResourceManager.GetString("DisplayNameDecoratesFileHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sign author に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DisplayNameSignsAuthor {
+            get {
+                return ResourceManager.GetString("DisplayNameSignsAuthor", resourceCulture);
             }
         }
         

--- a/projects/CommentGenerator/VSPackage.Designer.cs
+++ b/projects/CommentGenerator/VSPackage.Designer.cs
@@ -133,6 +133,15 @@ namespace CommentGenerator {
         }
         
         /// <summary>
+        ///   If set to true, write copyright to the file header. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DescriptionWritesCopyright {
+            get {
+                return ResourceManager.GetString("DescriptionWritesCopyright", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Author に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DisplayNameAuthor {
@@ -156,6 +165,15 @@ namespace CommentGenerator {
         internal static string DisplayNameDateFormat {
             get {
                 return ResourceManager.GetString("DisplayNameDateFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Write copyright に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DisplayNameWritesCopyright {
+            get {
+                return ResourceManager.GetString("DisplayNameWritesCopyright", resourceCulture);
             }
         }
         

--- a/projects/CommentGenerator/VSPackage.Designer.cs
+++ b/projects/CommentGenerator/VSPackage.Designer.cs
@@ -133,6 +133,24 @@ namespace CommentGenerator {
         }
         
         /// <summary>
+        ///   If set to true, add decoration to the comments of class, function and etc.. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DescriptionDecoratesComment {
+            get {
+                return ResourceManager.GetString("DescriptionDecoratesComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   If set to true, add decoration to the file header comments. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DescriptionDecoratesFileHeader {
+            get {
+                return ResourceManager.GetString("DescriptionDecoratesFileHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   If set to true, write copyright to the file header. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DescriptionWritesCopyright {
@@ -165,6 +183,24 @@ namespace CommentGenerator {
         internal static string DisplayNameDateFormat {
             get {
                 return ResourceManager.GetString("DisplayNameDateFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Decorate comments に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DisplayNameDecoratesComment {
+            get {
+                return ResourceManager.GetString("DisplayNameDecoratesComment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Decorate file header に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DisplayNameDecoratesFileHeader {
+            get {
+                return ResourceManager.GetString("DisplayNameDecoratesFileHeader", resourceCulture);
             }
         }
         

--- a/projects/CommentGenerator/VSPackage.Designer.cs
+++ b/projects/CommentGenerator/VSPackage.Designer.cs
@@ -88,6 +88,24 @@ namespace CommentGenerator {
         }
         
         /// <summary>
+        ///   Formats に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string CategoryFormats {
+            get {
+                return ResourceManager.GetString("CategoryFormats", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Signings に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string CategorySignings {
+            get {
+                return ResourceManager.GetString("CategorySignings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Name used for author item of document comment. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DescriptionAuthor {

--- a/projects/CommentGenerator/VSPackage.ja.resx
+++ b/projects/CommentGenerator/VSPackage.ja.resx
@@ -141,6 +141,9 @@
   <data name="DescriptionDateFormat" xml:space="preserve">
     <value>DateTime.ToString関数で使用されるものと同じ形式の、日付フォーマット文字列。</value>
   </data>
+  <data name="DescriptionWritesCopyright" xml:space="preserve">
+    <value>trueを設定されている時、ファイルヘッダーにコピーライトを記述するようになる。</value>
+  </data>
   <data name="DisplayNameAuthor" xml:space="preserve">
     <value>開発者</value>
   </data>
@@ -149,6 +152,9 @@
   </data>
   <data name="DisplayNameDateFormat" xml:space="preserve">
     <value>日付フォーマット</value>
+  </data>
+  <data name="DisplayNameWritesCopyright" xml:space="preserve">
+    <value>コピーライトを記述</value>
   </data>
   <data name="ErrorMessageTitle" xml:space="preserve">
     <value>失敗</value>

--- a/projects/CommentGenerator/VSPackage.ja.resx
+++ b/projects/CommentGenerator/VSPackage.ja.resx
@@ -126,6 +126,12 @@
   <data name="CategoryConstants" xml:space="preserve">
     <value>定数</value>
   </data>
+  <data name="CategoryFormats" xml:space="preserve">
+    <value>フォーマット</value>
+  </data>
+  <data name="CategorySignings" xml:space="preserve">
+    <value>署名</value>
+  </data>
   <data name="DescriptionAuthor" xml:space="preserve">
     <value>ドキュメントコメントのauthor項目において使用される、開発者の名前。</value>
   </data>

--- a/projects/CommentGenerator/VSPackage.ja.resx
+++ b/projects/CommentGenerator/VSPackage.ja.resx
@@ -147,6 +147,9 @@
   <data name="DescriptionDecoratesFileHeader" xml:space="preserve">
     <value>trueが設定されている時、ファイルヘッダーのコメントに装飾を追加する。</value>
   </data>
+  <data name="DescriptionSignsAuthor" xml:space="preserve">
+    <value>著者の記述をどこに行うかを決定する。</value>
+  </data>
   <data name="DescriptionWritesCopyright" xml:space="preserve">
     <value>trueが設定されている時、ファイルヘッダーにコピーライトを記述するようになる。</value>
   </data>
@@ -164,6 +167,9 @@
   </data>
   <data name="DisplayNameDecoratesFileHeader" xml:space="preserve">
     <value>ファイルヘッダーを装飾</value>
+  </data>
+  <data name="DisplayNameSignsAuthor" xml:space="preserve">
+    <value>開発者を記述</value>
   </data>
   <data name="DisplayNameWritesCopyright" xml:space="preserve">
     <value>コピーライトを記述</value>

--- a/projects/CommentGenerator/VSPackage.ja.resx
+++ b/projects/CommentGenerator/VSPackage.ja.resx
@@ -141,8 +141,14 @@
   <data name="DescriptionDateFormat" xml:space="preserve">
     <value>DateTime.ToString関数で使用されるものと同じ形式の、日付フォーマット文字列。</value>
   </data>
+  <data name="DescriptionDecoratesComment" xml:space="preserve">
+    <value>trueが設定されている時、クラス・関数・その他のコメントに装飾を追加する。</value>
+  </data>
+  <data name="DescriptionDecoratesFileHeader" xml:space="preserve">
+    <value>trueが設定されている時、ファイルヘッダーのコメントに装飾を追加する。</value>
+  </data>
   <data name="DescriptionWritesCopyright" xml:space="preserve">
-    <value>trueを設定されている時、ファイルヘッダーにコピーライトを記述するようになる。</value>
+    <value>trueが設定されている時、ファイルヘッダーにコピーライトを記述するようになる。</value>
   </data>
   <data name="DisplayNameAuthor" xml:space="preserve">
     <value>開発者</value>
@@ -152,6 +158,12 @@
   </data>
   <data name="DisplayNameDateFormat" xml:space="preserve">
     <value>日付フォーマット</value>
+  </data>
+  <data name="DisplayNameDecoratesComment" xml:space="preserve">
+    <value>コメントを装飾</value>
+  </data>
+  <data name="DisplayNameDecoratesFileHeader" xml:space="preserve">
+    <value>ファイルヘッダーを装飾</value>
   </data>
   <data name="DisplayNameWritesCopyright" xml:space="preserve">
     <value>コピーライトを記述</value>

--- a/projects/CommentGenerator/VSPackage.resx
+++ b/projects/CommentGenerator/VSPackage.resx
@@ -147,6 +147,9 @@
   <data name="DescriptionDecoratesFileHeader" xml:space="preserve">
     <value>If set to true, add decoration to the file header comments.</value>
   </data>
+  <data name="DescriptionSignsAuthor" xml:space="preserve">
+    <value>Decide where to write the author's sign.</value>
+  </data>
   <data name="DescriptionWritesCopyright" xml:space="preserve">
     <value>If set to true, write copyright to the file header.</value>
   </data>
@@ -164,6 +167,9 @@
   </data>
   <data name="DisplayNameDecoratesFileHeader" xml:space="preserve">
     <value>Decorate file header</value>
+  </data>
+  <data name="DisplayNameSignsAuthor" xml:space="preserve">
+    <value>Sign author</value>
   </data>
   <data name="DisplayNameWritesCopyright" xml:space="preserve">
     <value>Write copyright</value>

--- a/projects/CommentGenerator/VSPackage.resx
+++ b/projects/CommentGenerator/VSPackage.resx
@@ -126,6 +126,12 @@
   <data name="CategoryConstants" xml:space="preserve">
     <value>Constants</value>
   </data>
+  <data name="CategoryFormats" xml:space="preserve">
+    <value>Formats</value>
+  </data>
+  <data name="CategorySignings" xml:space="preserve">
+    <value>Signings</value>
+  </data>
   <data name="DescriptionAuthor" xml:space="preserve">
     <value>Name used for author item of document comment.</value>
   </data>

--- a/projects/CommentGenerator/VSPackage.resx
+++ b/projects/CommentGenerator/VSPackage.resx
@@ -141,6 +141,12 @@
   <data name="DescriptionDateFormat" xml:space="preserve">
     <value>Date format string in the same format as used in DateTime.ToString function.</value>
   </data>
+  <data name="DescriptionDecoratesComment" xml:space="preserve">
+    <value>If set to true, add decoration to the comments of class, function and etc..</value>
+  </data>
+  <data name="DescriptionDecoratesFileHeader" xml:space="preserve">
+    <value>If set to true, add decoration to the file header comments.</value>
+  </data>
   <data name="DescriptionWritesCopyright" xml:space="preserve">
     <value>If set to true, write copyright to the file header.</value>
   </data>
@@ -152,6 +158,12 @@
   </data>
   <data name="DisplayNameDateFormat" xml:space="preserve">
     <value>Date format</value>
+  </data>
+  <data name="DisplayNameDecoratesComment" xml:space="preserve">
+    <value>Decorate comments</value>
+  </data>
+  <data name="DisplayNameDecoratesFileHeader" xml:space="preserve">
+    <value>Decorate file header</value>
   </data>
   <data name="DisplayNameWritesCopyright" xml:space="preserve">
     <value>Write copyright</value>

--- a/projects/CommentGenerator/VSPackage.resx
+++ b/projects/CommentGenerator/VSPackage.resx
@@ -141,6 +141,9 @@
   <data name="DescriptionDateFormat" xml:space="preserve">
     <value>Date format string in the same format as used in DateTime.ToString function.</value>
   </data>
+  <data name="DescriptionWritesCopyright" xml:space="preserve">
+    <value>If set to true, write copyright to the file header.</value>
+  </data>
   <data name="DisplayNameAuthor" xml:space="preserve">
     <value>Author</value>
   </data>
@@ -149,6 +152,9 @@
   </data>
   <data name="DisplayNameDateFormat" xml:space="preserve">
     <value>Date format</value>
+  </data>
+  <data name="DisplayNameWritesCopyright" xml:space="preserve">
+    <value>Write copyright</value>
   </data>
   <data name="ErrorMessageTitle" xml:space="preserve">
     <value>Failed</value>

--- a/projects/CommentGenerator/source.extension.vsixmanifest
+++ b/projects/CommentGenerator/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="CommentExtension.c03e9f5d-d3ac-4444-9341-f8b08528dd60" Version="3.0.0" Language="en-US" Publisher="ELIONIX" />
+        <Identity Id="CommentExtension.c03e9f5d-d3ac-4444-9341-f8b08528dd60" Version="3.1.0" Language="en-US" Publisher="ELIONIX" />
         <DisplayName>ELIONIX Document Comment Generator</DisplayName>
         <Description xml:space="preserve">Provide a context menu to generate a template for document comments in source code.</Description>
         <MoreInfo>https://github.com/ELIONIX/CommentGenerator</MoreInfo>


### PR DESCRIPTION
ファイルヘッダーやクラスコメントに付いてる装飾のうち、 * が含まれるものに関して、範囲コメントアウトで囲ったときに邪魔にならないように、 = を使ったものに変更しました。
また、設定項目を増やして、フォーマットを切り替えられるようにしました。
設定のカテゴリーに変更がありますが、試した限りだと設定は飛ばないと思われます。

（設定を増やした件、本当は、新旧の装飾を変更出来るようにみたいな意図があったんですが、設定項目的に微妙な感じになってしまったので無くし、装飾のON/OFF等だけ残りました。）